### PR TITLE
Logモデルのバリデーションを設定

### DIFF
--- a/app/models/log.rb
+++ b/app/models/log.rb
@@ -1,5 +1,13 @@
 class Log < ApplicationRecord
   belongs_to :score
-  validates :content, presence: true
+  validates :content, presence: true, length: { maximum: 200 }
   validates :start_time, presence: true
+  validate :start_time_future
+
+  def start_time_future
+    if start_time.present? && start_time > Date.today
+      errors.add(:start_time, "未来の日付は登録できません" ) 
+    end
+  end
+
 end

--- a/spec/models/log_spec.rb
+++ b/spec/models/log_spec.rb
@@ -12,11 +12,27 @@ RSpec.describe Log, type: :model do
       end
     end
 
+    context "contentが200文字以上のとき" do
+      let(:log) { build(:log, content: "あ" * 201) }
+      it "エラーが発生する" do
+        expect(subject).to eq false
+        expect(log.errors[:content]).to include "は200文字以内で入力してください"
+      end
+    end
+
     context "start_time" do
       let(:log) { build(:log, start_time: "") }
       it "エラーが発生する" do
         expect(subject).to eq false
         expect(log.errors[:start_time]).to include "を入力してください"
+      end
+    end
+
+    context "start_time" do
+      let(:log) { build(:log, start_time: Date.today + 1) }
+      it "エラーが発生する" do
+        expect(subject).to eq false
+        expect(log.errors[:start_time]).to include "未来の日付は登録できません"
       end
     end
 


### PR DESCRIPTION
## 実装内容
- Logのバリデーションを追加
  - contentの文字数を200文字以内に制限
  - 未来の日付を入力できないように設定
- テストコードを追加