### PR TITLE
factory_botの不要な文を削除

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -34,6 +34,5 @@ module Music
 
     # Don't generate system test files.
     config.generators.system_tests = nil
-    config.factory_bot.definition_file_paths = ["spec/factories"] 
   end
 end


### PR DESCRIPTION
## 実装内容
- config/application.rbjから`config.factory_bot.definition_file_paths = ["spec/factories"]`を削除
  - herokuデプロイ時に`NoMethodError: undefined method factory_bot`のエラーが起きたため。