### PR TITLE
スコアモデルのバリデーションを追加

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -43,6 +43,9 @@ img {
   max-width: 100%;
   display: block;
 }
+ul {
+  list-style: none;
+}
 .container{
   max-width: 1200px;
   margin: 0 auto;

--- a/app/models/score.rb
+++ b/app/models/score.rb
@@ -2,6 +2,7 @@ class Score < ApplicationRecord
   belongs_to :user
   has_many :logs, dependent: :destroy
   validates :title, presence: true, length: { in: 1..50 }
+  validates :point, allow_blank: true, length: { maximum: 100 }
   mount_uploader :icon, ImageUploader
 
   enum status: {

--- a/app/views/layouts/_error_messages.html.erb
+++ b/app/views/layouts/_error_messages.html.erb
@@ -1,0 +1,9 @@
+<% if @score.errors.any? %>
+  <div class="error_messages">
+    <ul>
+      <% @score.errors.full_messages.each do |msg| %>
+        <li><span style="color: red;"><%= msg %></span></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>

--- a/app/views/scores/_form.html.erb
+++ b/app/views/scores/_form.html.erb
@@ -1,3 +1,4 @@
+<%= render "layouts/error_messages" %>  
 <div class="content">
   <div class="form">
     <div class="record-area">

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,6 +1,12 @@
 ---
 ja:
   activerecord:
+    models:
+      score: 楽譜
+    attributes:
+      score:
+        title: タイトル
+        point: メモ
     errors:
       messages:
         record_invalid: 'バリデーションに失敗しました: %{errors}'

--- a/spec/models/score_spec.rb
+++ b/spec/models/score_spec.rb
@@ -20,6 +20,14 @@ RSpec.describe Score, type: :model do
       end
     end
 
+    context "point が101字以上のとき" do
+      let(:score) { build(:score, point: "a" * 101) }
+      it "エラーが発生する" do
+        expect(subject).to eq false
+        expect(score.errors[:point]).to include "は100文字以内で入力してください"
+      end
+    end
+
     context "楽譜が削除されたとき" do
       subject { score.destroy }
       let(:score) { create(:score) }


### PR DESCRIPTION
## 実装内容
- pointに文字制限のバリデーションを設定(100文字以下)
  - エラーメッセージを追加
  - テストを追加