### PR TITLE
楽譜詳細ページの見た目を修正

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -106,7 +106,7 @@ table td {
 
 @media only screen and (min-width:600px) and ( max-width:1200px) {
   .content {
-    margin: 30px;
+    margin: 80px 0px;
   }
 }
 

--- a/app/assets/stylesheets/modules/_score_show.scss
+++ b/app/assets/stylesheets/modules/_score_show.scss
@@ -21,11 +21,20 @@
     font-weight: 600;
   }
 }
+table.details {
+  table-layout: fixed;
+}
+th.details{
+  width: 100px;
+}
 .edit {
   margin-top: 15px;
 }
+.edit-icon {
+  text-decoration:none !important;
+}
 .fa-edit {
-  color: #565656;
+  color: #7EACC4;
 }
 .fa-trash-alt {
   color: #da4242;
@@ -85,13 +94,6 @@
     width: 100%;
     max-width: 700px;
   }
-  table.details {
-    width: 100%;
-  }
-  th.details,
-  td.details {
-    width: 10%;
-  }
 }
 
 @media only screen and (max-width:599px) {
@@ -136,9 +138,5 @@
   }
   table.details {
     width: 100%;
-  }
-  th.details,
-  td.details {
-    width: 30%;
   }
 }

--- a/app/views/scores/show.html.erb
+++ b/app/views/scores/show.html.erb
@@ -30,7 +30,7 @@
         </tbody>
       </table>
       <div class="edit">
-        <%= link_to edit_score_path(@score) do %>
+        <%= link_to edit_score_path(@score), class: 'edit-icon' do %>
           <i class="far fa-lg fa-edit fa-fw faa-pulse animated-hover"></i>
         <% end %>
         <%= link_to @score, method: :delete, data: { confirm: "楽譜を削除してもよろしいですか?" } do %>


### PR DESCRIPTION
## 実装内容
- fontawesomeの下線を消去
- テーブルの幅を変更