### PR TITLE
練習記録失敗時のエラーを解消

### DIFF
--- a/app/controllers/logs_controller.rb
+++ b/app/controllers/logs_controller.rb
@@ -8,8 +8,8 @@ class LogsController < ApplicationController
       flash[:info] = "練習記録を登録しました"
       redirect_to score_path(@score)
     else
-      flash.now[:danger] = "練習記録を登録できません"
-      render template: "scores/show"
+      flash[:danger] = "練習記録を登録できません"
+      redirect_to score_path(@score)
     end
   end
   

--- a/app/views/scores/show.html.erb
+++ b/app/views/scores/show.html.erb
@@ -52,7 +52,7 @@
           <%= f.text_area :content, placeholder: "練習記録", class: "text-box", required: true %>
         </div>
         <div>
-          <%= f.text_field :start_time, placeholder: "日付を選択", class: 'flatpickr', required: true %>
+          <%= f.text_field :start_time, placeholder: "日付を選択" , class: 'flatpickr', value: Date.today, required: true %>
         </div>
         <div>
           <%= f.submit "記録する", class: "button", id: "log-btn" %>


### PR DESCRIPTION
## 実装内容
- 登録失敗時のメソッドをrenderからredirect_toに変更
- 日付のデフォルト値を今日の日付に設定