### PR TITLE
楽譜詳細ページから一覧ページへ戻るためのアイコンを追加

### DIFF
--- a/app/views/scores/show.html.erb
+++ b/app/views/scores/show.html.erb
@@ -37,7 +37,7 @@
           <i class="far fa-lg fa-trash-alt fa-fw faa-wrench animated-hover"></i>
         <% end %>
         <%= link_to scores_path do %>
-          <i class="fas fa-log fa-sync-alt fa-fw faa-spin animated-hover"></i>
+          <i class="fas fa-log fa-reply fa-fw faa-passing-reverse animated-hover"></i>
         <% end %>
       </div>
     </div>

--- a/app/views/scores/show.html.erb
+++ b/app/views/scores/show.html.erb
@@ -36,6 +36,9 @@
         <%= link_to @score, method: :delete, data: { confirm: "楽譜を削除してもよろしいですか?" } do %>
           <i class="far fa-lg fa-trash-alt fa-fw faa-wrench animated-hover"></i>
         <% end %>
+        <%= link_to scores_path do %>
+          <i class="fas fa-log fa-sync-alt fa-fw faa-spin animated-hover"></i>
+        <% end %>
       </div>
     </div>
   </section>


### PR DESCRIPTION
## 実装内容
- 詳細ページから一覧ページへ戻るボタンがなかったため追加